### PR TITLE
Check coding standards in Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ circleci build --job run-unit-kernel-tests
 If you chose this CI provider, you can delete the `.circleci` directory.
 Then commit and push the set of changes.
 
-The Travis CI implementation currently runs unit and kernel tests. If you are well versed in Travis CI,
-please give us a hand and [contribute](dist/.travis.yml) so we can reach feature parity with the CircleCI
-implementation.
+The Travis CI implementation currently runs unit and kernel tests, and checks Drupal's coding standards.
+If you are well versed in Travis CI, please give us a hand and [contribute](dist/.travis.yml) so we can
+reach feature parity with the CircleCI implementation.
 
 #### Installation
 

--- a/dist/.circleci/config.yml
+++ b/dist/.circleci/config.yml
@@ -98,7 +98,7 @@ code_sniffer: &code_sniffer
         name: Set up and inspect coding standards
         command: |
           robo install:dependencies
-          vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer web/modules/custom
+          vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
           mkdir -p artifacts/phpcs
           vendor/bin/phpcs --standard=Drupal --report=junit --report-junit=artifacts/phpcs/phpcs.xml web/modules/custom
           vendor/bin/phpcs --standard=DrupalPractice --report=junit --report-junit=artifacts/phpcs/phpcs.xml web/modules/custom

--- a/dist/.travis.yml
+++ b/dist/.travis.yml
@@ -17,11 +17,21 @@ install:
   - composer --verbose install
 
 script:
+  # Install Drupal and start the web server.
   - cd web
-  - ./../vendor/bin/drush site-install --verbose --yes --db-url=$DRUPAL_DB
-  - ./../vendor/bin/drush runserver $DRUPAL_BASE_URL &
-  - cp ./../.travis/config/phpunit.xml core/
+  - ../vendor/bin/drush site-install --verbose --yes --db-url=$DRUPAL_DB
+  - ../vendor/bin/drush runserver $DRUPAL_BASE_URL &
   - until curl -s $DRUPAL_BASE_URL; do true; done > /dev/null
-  - ./../vendor/bin/phpunit -c core --debug --verbose modules/custom
+  - cd ..
 
+  # Run unit and kernel tests.
+  - cp .travis/config/phpunit.xml web/core/
+  - cd web
+  - ../vendor/bin/phpunit -c core --debug --verbose modules/custom
+  - cd ..
+
+  # Check Drupal's coding standards.
+  - vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
+  - vendor/bin/phpcs --standard=Drupal web/modules/custom
+  - vendor/bin/phpcs --standard=DrupalPractice web/modules/custom
 


### PR DESCRIPTION
Travis CI does not host artifacts like CircleCI does, so no report is generated.

Test run at https://travis-ci.org/juampynr/d8cidemo/builds/327377770.