### PR TITLE
Update composer in Drupal image

### DIFF
--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -22,7 +22,7 @@ RUN sed -ri -e 's!/var/www/html!/var/www/html/web!g' /etc/apache2/sites-availabl
 RUN sed -ri -e 's!/var/www!/var/www/html/web!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
 # Install composer.
-RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/f3333f3bc20ab8334f7f3dada808b8dfbfc46088/web/installer -O - -q | php -- --quiet
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/fe44bd5b10b89fbe7e7fc70e99e5d1a344a683dd/web/installer -O - -q | php -- --quiet
 RUN mv composer.phar /usr/local/bin/composer
 
 # Put a turbo on composer.


### PR DESCRIPTION
Found this in a project:

```
 [Deviantintegral\ComposerGavel\Exception\ConstraintException]                                                          
  Composer 1.6.3 is in use but this project requires Composer ^1.6.4. Upgrade composer by running composer self-update. 
```

Time to update composer.