### PR TITLE
Remove the memory limit for the PHP CLI

### DIFF
--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && apt-get install -y \
   && docker-php-ext-install pdo \
   && docker-php-ext-install pdo_mysql
 
+# Remove the memory limit for the CLI only.
+RUN echo 'memory_limit = -1' > /usr/local/etc/php/php-cli.ini
+
 # Remove the vanilla Drupal project that comes with this image.
 RUN rm -rf ..?* .[!.]* *
 


### PR DESCRIPTION
As is, it's limited to 128MB which is rather small for large CLI operations like `drush updatedb`.