### PR TITLE
drupal-extension error using master-dev

### DIFF
--- a/setup-circleci.sh
+++ b/setup-circleci.sh
@@ -32,7 +32,7 @@ drupal8ci_install() {
 		behat/mink-selenium2-driver:^1.3 \
 		bex/behat-screenshot \
 		drupal/coder:^8.2 \
-		drupal/drupal-extension:master-dev
+		drupal/drupal-extension:^4.0
 }
 
 #######################################


### PR DESCRIPTION
Similar to the change requested for GitLab. https://github.com/Lullabot/drupal8ci/commit/4fa7bc913c40daf77c9f31f7df2172b9e3a8f7a4

Having this set to `master-dev` is throwing this error.
```
  Problem 1
    - Installation request for drupal/drupal-extension master-dev -> satisfiable by drupal/drupal-extension[dev-master].
    - Conclusion: remove drupal/drupal-driver v1.4.0
    - Conclusion: don't install drupal/drupal-driver v1.4.0
    - drupal/drupal-extension dev-master requires drupal/drupal-driver ^2.0.0 -> satisfiable by drupal/drupal-driver[2.0.x-dev, v2.0.0-alpha1, v2.0.0-alpha2, v2.0.0-alpha3, v2.0.0-alpha4, v2.0.0-alpha5, v2.0.0-alpha6].
    - Can only install one of: drupal/drupal-driver[2.0.x-dev, v1.4.0].
    - Can only install one of: drupal/drupal-driver[v2.0.0-alpha1, v1.4.0].
    - Can only install one of: drupal/drupal-driver[v2.0.0-alpha2, v1.4.0].
    - Can only install one of: drupal/drupal-driver[v2.0.0-alpha3, v1.4.0].
    - Can only install one of: drupal/drupal-driver[v2.0.0-alpha4, v1.4.0].
    - Can only install one of: drupal/drupal-driver[v2.0.0-alpha5, v1.4.0].
    - Can only install one of: drupal/drupal-driver[v2.0.0-alpha6, v1.4.0].
    - Installation request for drupal/drupal-driver (locked at v1.4.0) -> satisfiable by drupal/drupal-driver[v1.4.0].```