### PR TITLE
Update Dockerfile to use 8.9-apache base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drupal:8.6-apache
+FROM drupal:8.9-apache
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/setup-circleci.sh
+++ b/setup-circleci.sh
@@ -25,10 +25,8 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the CircleCI jobs.
-	#
-	# behat/mink-extension is pinned until https://github.com/Behat/MinkExtension/pull/311 gets fixed.
 	composer require --dev \
-		behat/mink-extension:v2.2 \
+		behat/mink-extension:^2.3.1 \
 		behat/mink-selenium2-driver:^1.3 \
 		bex/behat-screenshot \
 		drupal/coder:^8.2 \


### PR DESCRIPTION
We use the `juampynr/drupal8ci` docker image in our project and we're updating our production environments to PHP 7.3, as well as our version of Drupal to 8.9.5. Updating the base image here to use `drupal:8.9-apache` to accomodate both changes.

Also resolving a version conflict with `behat/mink-extension`, which good news! We no longer need to pin the version on that requirement as the relevant upstream issue has since been resolved and tagged.