### PR TITLE
Issue #52 Remove adjustments to apache webroot, no longer required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,6 @@ RUN echo 'memory_limit = -1' > /usr/local/etc/php/php-cli.ini
 # Remove the vanilla Drupal project that comes with this image.
 RUN rm -rf ..?* .[!.]* *
 
-# Change docroot since we use Composer Drupal project.
-RUN sed -ri -e 's!/var/www/html!/var/www/html/web!g' /etc/apache2/sites-available/*.conf
-RUN sed -ri -e 's!/var/www!/var/www/html/web!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
-
 # Install composer.
 COPY scripts/composer-installer.sh /tmp/composer-installer.sh
 RUN chmod +x /tmp/composer-installer.sh


### PR DESCRIPTION
Now that the upstream image uses `drupal/recommended-project`, the upstream image already has the right directory structure layout and Apache config, such that we should no longer have to adjust the Apache weroot.