### PR TITLE
Require core-dev and run composer without memory limit

### DIFF
--- a/setup-circleci.sh
+++ b/setup-circleci.sh
@@ -25,12 +25,7 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the CircleCI jobs.
-	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
-		behat/mink-extension:^2.3.1 \
-		behat/mink-selenium2-driver:^1.3 \
-		bex/behat-screenshot \
-		drupal/coder:^8.2 \
-		drupal/drupal-extension:^4.0
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev
 }
 
 #######################################

--- a/setup-circleci.sh
+++ b/setup-circleci.sh
@@ -25,7 +25,9 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the CircleCI jobs.
-	COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
+		drupal/core-dev \
+		weitzman/drupal-test-traits:^1.2
 }
 
 #######################################

--- a/setup-circleci.sh
+++ b/setup-circleci.sh
@@ -25,7 +25,7 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the CircleCI jobs.
-	composer require --dev \
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
 		behat/mink-extension:^2.3.1 \
 		behat/mink-selenium2-driver:^1.3 \
 		bex/behat-screenshot \

--- a/setup-github-actions.sh
+++ b/setup-github-actions.sh
@@ -25,7 +25,7 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the jobs.
-	composer require --dev \
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
 		dmore/chrome-mink-driver:^2.7 \
 		weitzman/drupal-test-traits:^1.3 \
 		drupal/coder:^8.2 \

--- a/setup-github-actions.sh
+++ b/setup-github-actions.sh
@@ -25,12 +25,7 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the jobs.
-	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
-		dmore/chrome-mink-driver:^2.7 \
-		weitzman/drupal-test-traits:^1.3 \
-		drupal/coder:^8.2 \
-		consolidation/robo:^2.0 \
-		drush/drush
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev
 }
 
 #######################################

--- a/setup-github-actions.sh
+++ b/setup-github-actions.sh
@@ -25,8 +25,9 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the jobs.
-	COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev
-}
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
+		drupal/core-dev \
+		weitzman/drupal-test-traits:^1.2}
 
 #######################################
 # Helper function to output a string to stderr and exit.

--- a/setup-gitlab-ci.sh
+++ b/setup-gitlab-ci.sh
@@ -25,7 +25,7 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the GitLab CI jobs.
-	composer require --dev \
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
 		dmore/chrome-mink-driver:^2.7 \
 		weitzman/drupal-test-traits:^1.2 \
 		drupal/coder:^8.2 \

--- a/setup-gitlab-ci.sh
+++ b/setup-gitlab-ci.sh
@@ -25,12 +25,7 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the GitLab CI jobs.
-	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
-		dmore/chrome-mink-driver:^2.7 \
-		weitzman/drupal-test-traits:^1.2 \
-		drupal/coder:^8.2 \
-		consolidation/robo:^1.4 \
-		drush/drush
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev
 }
 
 #######################################

--- a/setup-gitlab-ci.sh
+++ b/setup-gitlab-ci.sh
@@ -25,7 +25,9 @@ drupal8ci_install() {
 	rsync -va --ignore-existing "$tmpdir/drupal8ci-master/dist/common/" .
 
 	# Add development dependencies to run the GitLab CI jobs.
-	COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
+		drupal/core-dev \
+		weitzman/drupal-test-traits:^1.2
 }
 
 #######################################

--- a/setup-travis-ci.sh
+++ b/setup-travis-ci.sh
@@ -27,7 +27,7 @@ drupal8ci_install() {
 	# Add development dependencies to run the Travis CI jobs.
 	#
 	# behat/mink-extension is pinned until https://github.com/Behat/MinkExtension/pull/311 gets fixed.
-	composer require --dev \
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
 		behat/mink-extension:v2.2 \
 		behat/mink-selenium2-driver:^1.3 \
 		bex/behat-screenshot \

--- a/setup-travis-ci.sh
+++ b/setup-travis-ci.sh
@@ -27,13 +27,7 @@ drupal8ci_install() {
 	# Add development dependencies to run the Travis CI jobs.
 	#
 	# behat/mink-extension is pinned until https://github.com/Behat/MinkExtension/pull/311 gets fixed.
-	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
-		behat/mink-extension:v2.2 \
-		behat/mink-selenium2-driver:^1.3 \
-		bex/behat-screenshot \
-		drupal/coder:^8.2 \
-		drupal/drupal-extension:master-dev \
-		php-coveralls/php-coveralls
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev
 }
 
 #######################################

--- a/setup-travis-ci.sh
+++ b/setup-travis-ci.sh
@@ -27,7 +27,9 @@ drupal8ci_install() {
 	# Add development dependencies to run the Travis CI jobs.
 	#
 	# behat/mink-extension is pinned until https://github.com/Behat/MinkExtension/pull/311 gets fixed.
-	COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev
+	COMPOSER_MEMORY_LIMIT=-1 composer require --dev \
+		drupal/core-dev \
+		weitzman/drupal-test-traits:^1.2
 }
 
 #######################################


### PR DESCRIPTION
Fixes https://github.com/Lullabot/drupal8ci/issues/29

When trying to set this up I was getting first composer memory errors/issues. Once I got over that I was getting missing packages/extensions that are brought by `core-dev`.